### PR TITLE
Struct for Markets and SimplifiedMarkets Responses

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,7 @@ use crate::Decimal;
 use crate::SignedOrderRequest;
 use alloy_primitives::U256;
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -326,4 +327,72 @@ pub struct ApiCreds {
     pub api_key: String,
     pub secret: String,
     pub passphrase: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MarketsResponse {
+    pub limit: Decimal,
+    pub count: Decimal,
+    pub next_cursor: Option<String>,
+    pub data: Vec<Market>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimplifiedMarketsResponse {
+    pub limit: Decimal,
+    pub count: Decimal,
+    pub next_cursor: Option<String>,
+    pub data: Vec<SimplifiedMarket>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Market {
+    pub condition_id: String,
+    pub tokens: [Token; 2],
+    pub rewards: Rewards,
+    pub min_incentive_size: Option<String>,
+    pub max_incentive_spread: Option<String>,
+    pub active: bool,
+    pub closed: bool,
+
+    pub question_id: String,
+    pub minimum_order_size: Decimal,
+    pub minimum_tick_size: Decimal,
+    pub description: String,
+    pub category: Option<String>,
+    pub end_date_iso: Option<String>,
+    pub game_start_time: Option<String>,
+    pub question: String,
+    pub market_slug: String,
+    pub seconds_delay: Decimal,
+    pub icon: String,
+    pub fpmm: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimplifiedMarket {
+    pub condition_id: String,
+    pub tokens: [Token; 2],
+    pub rewards: Rewards,
+    pub min_incentive_size: Option<String>,
+    pub max_incentive_spread: Option<String>,
+    pub active: bool,
+    pub closed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Token {
+    pub token_id: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Rewards {
+    pub rates: Option<Value>,
+    pub min_size: Decimal,
+    pub max_spread: Decimal,
+    pub event_start_date: Option<String>,
+    pub event_end_date: Option<String>,
+    pub in_game_multiplier: Option<Decimal>,
+    pub reward_epoch: Option<Decimal>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,7 @@ impl ClobClient {
             .await?)
     }
 
-    pub async fn get_sampling_markets(&self, next_cursor: Option<&str>) -> ClientResult<Value> {
+    pub async fn get_sampling_markets(&self, next_cursor: Option<&str>) -> ClientResult<MarketsResponse> {
         let next_cursor = next_cursor.unwrap_or(INITIAL_CURSOR);
 
         Ok(self
@@ -842,14 +842,14 @@ impl ClobClient {
             .query(&[("next_cursor", next_cursor)])
             .send()
             .await?
-            .json::<Value>()
+            .json::<MarketsResponse>()
             .await?)
     }
 
     pub async fn get_sampling_simplified_markets(
         &self,
         next_cursor: Option<&str>,
-    ) -> ClientResult<Value> {
+    ) -> ClientResult<SimplifiedMarketsResponse> {
         let next_cursor = next_cursor.unwrap_or(INITIAL_CURSOR);
 
         Ok(self
@@ -858,11 +858,11 @@ impl ClobClient {
             .query(&[("next_cursor", next_cursor)])
             .send()
             .await?
-            .json::<Value>()
+            .json::<SimplifiedMarketsResponse>()
             .await?)
     }
 
-    pub async fn get_markets(&self, next_cursor: Option<&str>) -> ClientResult<Value> {
+    pub async fn get_markets(&self, next_cursor: Option<&str>) -> ClientResult<MarketsResponse> {
         let next_cursor = next_cursor.unwrap_or(INITIAL_CURSOR);
 
         Ok(self
@@ -871,11 +871,14 @@ impl ClobClient {
             .query(&[("next_cursor", next_cursor)])
             .send()
             .await?
-            .json::<Value>()
+            .json::<MarketsResponse>()
             .await?)
     }
 
-    pub async fn get_simplified_markets(&self, next_cursor: Option<&str>) -> ClientResult<Value> {
+    pub async fn get_simplified_markets(
+        &self,
+        next_cursor: Option<&str>,
+    ) -> ClientResult<SimplifiedMarketsResponse> {
         let next_cursor = next_cursor.unwrap_or(INITIAL_CURSOR);
 
         Ok(self
@@ -884,17 +887,17 @@ impl ClobClient {
             .query(&[("next_cursor", next_cursor)])
             .send()
             .await?
-            .json::<Value>()
+            .json::<SimplifiedMarketsResponse>()
             .await?)
     }
 
-    pub async fn get_market(&self, condition_id: &str) -> ClientResult<Value> {
+    pub async fn get_market(&self, condition_id: &str) -> ClientResult<Market> {
         Ok(self
             .http_client
             .get(format!("{}/markets/{condition_id}", &self.host))
             .send()
             .await?
-            .json::<Value>()
+            .json::<Market>()
             .await?)
     }
 


### PR DESCRIPTION
Instead of returning the response of the markets endpoints in a `serde_json::Value` struct, I thought it might be nice to capture this in a dedicated struct. 