### PR TITLE
fix: get_trades, query builder error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,7 +671,7 @@ impl ClobClient {
                 .http_client
                 .request(method.clone(), format!("{}{endpoint}", &self.host))
                 .query(&query_params)
-                .query(&["next_cursor", &next_cursor]);
+                .query(&[("next_cursor", &next_cursor)]);
 
             let r = headers
                 .clone()


### PR DESCRIPTION
Query params should be passed as list of tuples, otherwise raises `unsupported pair` from reqwest.