### PR TITLE
fix: "Unauthorized/Invalid api key" response when creating order

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use serde::Serialize;
 use std::collections::HashMap;
 
-const POLY_ADDR_HEADER: &str = "poly_address";
-const POLY_SIG_HEADER: &str = "poly_signature";
-const POLY_TS_HEADER: &str = "poly_timestamp";
-const POLY_NONCE_HEADER: &str = "poly_nonce";
-const POLY_API_KEY_HEADER: &str = "poly_api_key";
-const POLY_PASS_HEADER: &str = "poly_passphrase";
+const POLY_ADDR_HEADER: &str = "POLY_ADDRESS";
+const POLY_SIG_HEADER: &str = "POLY_SIGNATURE";
+const POLY_TS_HEADER: &str = "POLY_TIMESTAMP";
+const POLY_NONCE_HEADER: &str = "POLY_NONCE";
+const POLY_API_KEY_HEADER: &str = "POLY_API_KEY";
+const POLY_PASS_HEADER: &str = "POLY_PASSPHRASE";
 
 //TODO: Heapless for maps!
 type Headers = HashMap<&'static str, String>;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::URL_SAFE, Engine};
 use serde::Serialize;
-use serde_json_fmt::JsonFormat;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use hmac::{Hmac, Mac};
@@ -32,11 +31,8 @@ where
     let message = match body {
         None => format!("{timestamp}{method}{req_path}"),
         Some(s) => {
-            // We format like str(dict) in python
-            let s = JsonFormat::new()
-                .comma(", ")?
-                .colon(": ")?
-                .format_to_string(&s)?;
+            // Use compact JSON (no spaces) like standard JSON.stringify
+            let s = serde_json::to_string(&s).context("Failed to serialize body")?;
             format!("{timestamp}{method}{req_path}{s}")
         }
     };


### PR DESCRIPTION
The `polymarket-rs-client` v0.1.1 library was failing with "Unauthorized/Invalid api key" error when trying to place orders, even though:
- API credentials were valid
- Other authenticated endpoints (like `get_api_keys()`) worked
- The same wallet and credentials worked perfectly with the Python client

The main reason of this type of failure when trying to submit order using EOA key is because HTTP headers and JSON for HMAC signatures:

1. HTTP headers ARE case-sensitive for Polymarket's API (or at least for HMAC calculation)
2. JSON formatting matters for HMAC signatures - must be compact without spaces (The Python client uses `json.dumps()` which produces compact JSON by default)

## Credits
Fixed through systematic comparison with the official Python client (`py-clob-client`) implementation.
